### PR TITLE
feat: Implement parsing for Java features up to Java 22 (partial)

### DIFF
--- a/javalang/javadoc.py
+++ b/javalang/javadoc.py
@@ -45,6 +45,15 @@ class DocBlock(object):
         elif name == 'deprecated':
             self.deprecated = True
 
+        # Explicitly recognize snippet, though default handling is the same.
+        # For inline snippets like {@snippet ...}, this parser would need significant
+        # enhancements as it currently only processes block tags.
+        # The existing mechanism will store the full content of an @snippet block tag.
+        elif name == 'snippet':
+            # The value already contains the full content of the block tag.
+            # The default setdefault below would handle this too.
+            pass # Fall through to default handling
+
         self.tags.setdefault(name, []).append(value)
 
 blocks_re = re.compile('(^@)', re.MULTILINE)

--- a/javalang/tree.py
+++ b/javalang/tree.py
@@ -4,7 +4,7 @@ from .ast import Node
 # ------------------------------------------------------------------------------
 
 class CompilationUnit(Node):
-    attrs = ("package", "imports", "types")
+    attrs = ("package", "imports", "declarations") # Renamed types to declarations
 
 class Import(Node):
     attrs = ("path", "static", "wildcard")
@@ -225,7 +225,13 @@ class SwitchExpression(Expression):
     attrs = ("selector", "cases")
 
 class InstanceOfPatternExpression(Expression):
-    attrs = ("expression", "type", "pattern_variable")
+    attrs = ("expression", "type", "pattern") # Renamed pattern_variable to pattern
+
+class RecordPattern(Node):
+    attrs = ("type", "components")
+
+class StringTemplate(Expression):
+    attrs = ("processor", "fragments", "expressions")
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit introduces parsing support for a wide range of Java language features from Java 10 through Java 21/22 (preview features), significantly extending the capabilities of the javalang library.

Key changes include:

1.  **Tokenizer Enhancements:**
    *   Added new keywords: `var`, `yield`, `record`, `sealed`, `non-sealed`, `permits`, `when`.
    *   Ensured `_` is treated as an identifier for unnamed variables/patterns.

2.  **AST Node Additions/Modifications:**
    *   `SwitchExpression`, `SwitchRule`, `YieldStatement` for switch expressions.
    *   `RecordDeclaration` for records.
    *   `InstanceOfPatternExpression` for pattern matching with `instanceof`.
    *   `RecordPattern` for record destructuring in `instanceof` and `switch`.
    *   `StringTemplate` for string templates with embedded expressions.
    *   Modified `ClassDeclaration`, `InterfaceDeclaration` to support `permits` for sealed types.
    *   Modified `SwitchStatementCase` and `SwitchRule` to support pattern labels and guards.
    *   Modified `CompilationUnit` to allow top-level method declarations (for unnamed classes/instance main methods).

3.  **Parser Logic Implementation for New Features:**
    *   Local-Variable Type Inference (`var`).
    *   Switch Expressions and Statements (including `yield`, type patterns, `null` cases, `when` guards).
    *   Text Blocks (tokenizer and parser).
    *   Records.
    *   Pattern Matching for `instanceof` (type patterns, record patterns).
    *   Record Patterns in `switch`.
    *   Unnamed Classes and Instance Main Methods (top-level methods).
    *   String Templates (`PROCESSOR."..."` syntax with embedded expression parsing).
    *   Basic support for Javadoc block `@snippet` tags.

4.  **Testing:**
    *   Added a new test file (`javalang/test/test_java_10_to_14_features.py`, later consolidated and renamed `TestJavaModernFeatures`) with basic unit tests for most of the newly implemented features, verifying AST structure.

**Known Limitations/Skipped Items:**
*   I attempted to implement parsing for "Statements before super(...)" (Java 22 Preview) but encountered some issues and had to skip it for now.
*   Inline Javadoc `{@snippet}` tags are not supported.
*   Testing is foundational and not exhaustive for all edge cases.
*   Full compliance review against all minor grammar changes up to Java 22 has not been performed.

This represents a major update towards Java 22 compatibility for `javalang`.